### PR TITLE
upgrade gripmock-sdk-go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ COPY . /go/src/github.com/bavix/gripmock
 
 WORKDIR /go/src/github.com/bavix/gripmock
 
-RUN go build -o /dev/null . && rm -rf /root/.cache
+RUN go build -o /dev/null .
 
 EXPOSE 4770 4771
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,7 +38,7 @@ var rootCmd = &cobra.Command{
 			}
 		}()
 
-		return builder.GRPCServe(cmd.Context(), proto.NewProtocParam(args, outputFlag, importsFlag))
+		return builder.GRPCServe(ctx, proto.NewProtocParam(args, outputFlag, importsFlag))
 	},
 }
 

--- a/deployments/docker-compose/docker-compose.yml
+++ b/deployments/docker-compose/docker-compose.yml
@@ -3,46 +3,56 @@ services:
   ms:
     image: bavix/gripmock:latest
     entrypoint: example/ms/entrypoint.sh
+    environment: &env
+      LOG_LEVEL: debug
     volumes:
       - ./../../protogen/example/ms:/go/src/github.com/bavix/gripmock/protogen/example/ms
   multi-files:
     image: bavix/gripmock:latest
     entrypoint: example/multi-files/entrypoint.sh
+    environment: *env
     volumes:
       - ./../../protogen/example/multi-files:/go/src/github.com/bavix/gripmock/protogen/example/multi-files
   multi-package:
     image: bavix/gripmock:latest
     entrypoint: example/multi-package/entrypoint.sh
+    environment: *env
     volumes:
       - ./../../protogen/example/multi-package:/go/src/github.com/bavix/gripmock/protogen/example/multi-package
   one-of:
     image: bavix/gripmock:latest
     entrypoint: example/one-of/entrypoint.sh
+    environment: *env
     volumes:
       - ./../../protogen/example/one-of:/go/src/github.com/bavix/gripmock/protogen/example/one-of
   simple:
     image: bavix/gripmock:latest
     entrypoint: example/simple/entrypoint.sh
+    environment: *env
     volumes:
       - ./../../protogen/example/simple:/go/src/github.com/bavix/gripmock/protogen/example/simple
   stream:
     image: bavix/gripmock:latest
     entrypoint: example/stream/entrypoint.sh
+    environment: *env
     volumes:
       - ./../../protogen/example/stream:/go/src/github.com/bavix/gripmock/protogen/example/stream
   stub-subfolders:
     image: bavix/gripmock:latest
     entrypoint: example/stub-subfolders/entrypoint.sh
+    environment: *env
     volumes:
       - ./../../protogen/example/stub-subfolders:/go/src/github.com/bavix/gripmock/protogen/example/stub-subfolders
   well_known_types:
     image: bavix/gripmock:latest
     entrypoint: example/well_known_types/entrypoint.sh
+    environment: *env
     volumes:
       - ./../../protogen/example/well_known_types:/go/src/github.com/bavix/gripmock/protogen/example/well_known_types
   strict-mode:
     image: bavix/gripmock:latest
     entrypoint: example/strictmode/entrypoint.sh
+    environment: *env
     volumes:
       - ./../../protogen/example/strictmode:/go/src/github.com/bavix/gripmock/protogen/example/strictmode
   

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.2
 
 require (
 	github.com/bavix/features v1.0.0
-	github.com/bavix/gripmock-sdk-go v1.0.4
+	github.com/bavix/gripmock-sdk-go v1.0.5
 	github.com/bavix/gripmock-ui v1.0.0-alpha7
 	github.com/bavix/gripmock/protogen v0.0.0-20240802051438-1db64f731414
 	github.com/cristalhq/base64 v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7D
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/bavix/features v1.0.0 h1:KyJzP1aKdTWSO7RxwX0Hega9qHUrSdiwdhI+uhAjUg4=
 github.com/bavix/features v1.0.0/go.mod h1:OLOA0UEsGMPY0Ofc/4kjajVB/H1zvITPAegB9RkewqM=
-github.com/bavix/gripmock-sdk-go v1.0.4 h1:FDBlusqVFoy5Yo49khztYqfVt9+NSEf1mIl1nQWoTr4=
-github.com/bavix/gripmock-sdk-go v1.0.4/go.mod h1:/1cmn8VuN6Pc7ttMejqXLYpvf1CJF08ezoEA9lJIZiU=
+github.com/bavix/gripmock-sdk-go v1.0.5 h1:DFZIz5aobjBIsMmBptHkuSdhGzOPlqp3Gn1qHms4DO0=
+github.com/bavix/gripmock-sdk-go v1.0.5/go.mod h1:/+9vHE4ccPeV+5RecNGpy9NMwccDglH3IeXsrLWVvaY=
 github.com/bavix/gripmock-ui v1.0.0-alpha7 h1:0VDKdaUWgMBPURsLXtSt0FmCK4MKSxlSq+8u0ukfois=
 github.com/bavix/gripmock-ui v1.0.0-alpha7/go.mod h1:XEH4YYEKL+wEDtONntoWm6JxjbVWzl7XtDYztUTBfeA=
 github.com/bavix/gripmock/protogen v0.0.0-20240802051438-1db64f731414 h1:86SxL7Nisq6uGxLlzjAAOw26k3wrsLEHafgOgouhVoQ=

--- a/internal/domain/servergen/gen.go
+++ b/internal/domain/servergen/gen.go
@@ -75,6 +75,13 @@ func ServerGenerate(ctx context.Context, param *proto.ProtocParam) error {
 	protoc.Stdout = os.Stdout
 	protoc.Stderr = os.Stderr
 
+	// Run the protoc command.
+	zerolog.Ctx(ctx).
+		Debug().
+		Str("path", protoc.Path).
+		Strs("args", protoc.Args).
+		Msg("building gRPC server")
+
 	return protoc.Run()
 }
 


### PR DESCRIPTION
~~Removing the cache resulted in a 10x decrease in pipeline performance....~~

Hmm. slow work only on darwin...

I need to compare the size of the image with and without cache.

then make a decision.