### PR TITLE
Reduce Docker healthcheck interval during startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,7 @@ RUN go build -o /dev/null .
 
 EXPOSE 4770 4771
 
-HEALTHCHECK CMD gripmock check --silent
+HEALTHCHECK --start-interval=1s --start-period=30s \
+    CMD gripmock check --silent
 
 ENTRYPOINT ["gripmock"]


### PR DESCRIPTION
Currently the [default healthcheck interval of 30s](https://docs.docker.com/reference/dockerfile/#healthcheck) is used for reporting on the health status of the gripmock server during startup. 

This means that given the following compose file, the `my-app` service will not start for 30 seconds, even though the gripmock server is ready after 1-3 seconds:
```yaml
services:
  my-app:
    ...
    depends_on:
      gripmock:
        condition: service_healthy
    ...
  gripmock:
    image: bavix/gripmock
    ...
```

This PR adds the `--start-period` and `--start-interval` args to the healthcheck, so it runs every second for the first 30 seconds of running the image, then defaults back to every 30s after this (or after the healthcheck returns healthy, whichever is first). 

It is worth noting that retries are not counted during the specified `start-period` and are only counted after this. I haven't see the start period take over 3 seconds with this change, but if there was a significant number of protos etc. then it may take longer, but this would be an issue with the current configuration anyway 🤷 