### PR TITLE
workaround for hadolint start-interval support

### DIFF
--- a/.github/workflows/hadolint.yaml
+++ b/.github/workflows/hadolint.yaml
@@ -9,7 +9,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        # TODO: remove this step once this fix to support --start-interval 
+        # has been released: https://github.com/hadolint/language-docker/pull/98
+        # and the hadolint-action has been updated to use it.
+      - name: Temp hadolint workaround
+        run: sed 's/\--start-interval=1s //g' Dockerfile > Dockerfile.hadolint
       - name: Run hadolint
         uses: hadolint/hadolint-action@v3.1.0
         with:
-          dockerfile: Dockerfile
+          dockerfile: Dockerfile.hadolint


### PR DESCRIPTION
https://github.com/bavix/gripmock/pull/524 was merged with a broken hadolint workflow, this is due to a lack of support for the `start-interval` flag on healthchecks. This has been fixed in hadolint (https://github.com/hadolint/language-docker/pull/98) but not yet released, so this PR adds a temporary workaround inspired by this comment: https://github.com/hadolint/hadolint/issues/978#issuecomment-2661597203