### PR TITLE
Fix server streaming error stubs to return proper gRPC errors

### DIFF
--- a/internal/app/grpc_server.go
+++ b/internal/app/grpc_server.go
@@ -429,6 +429,11 @@ func (m *grpcMocker) handleArrayStreamData(stream grpc.ServerStream, found *stub
 }
 
 func (m *grpcMocker) handleNonArrayStreamData(stream grpc.ServerStream, found *stuber.Stub) error {
+	// Check for output error before attempting to send data
+	if err := m.handleOutputError(stream.Context(), stream, found.Output); err != nil {
+		return err
+	}
+
 	// Original behavior for non-array data, with context cancellation check
 	done := stream.Context().Done()
 


### PR DESCRIPTION
- Add error check in handleNonArrayStreamData before marshaling data
- Prevents JSON unmarshaling error when Output.Data is nil
- Ensures error-only server streaming stubs work correctly

bug report: #709 