### PR TITLE
Add real-world example to Embedded SDK documentation

### DIFF
--- a/docs/guide/embedded-sdk/index.md
+++ b/docs/guide/embedded-sdk/index.md
@@ -10,6 +10,12 @@
 
 The GripMock Embedded SDK provides an integrated way to use GripMock directly within your Go tests without requiring external processes or containers. This approach offers faster test execution and better integration with your development workflow.
 
+## Real-World Example
+
+Looking for a full project that uses embedded mode in practice?
+
+- [bavix/greeter-gripmock-embedded](https://github.com/bavix/greeter-gripmock-embedded) - End-to-end example of GripMock Embedded SDK usage
+
 ## Why Use the Embedded SDK?
 
 The GripMock Embedded SDK offers several key advantages over traditional external mock server approaches:


### PR DESCRIPTION
- Included a new section with a link to a full project demonstrating the use of the GripMock Embedded SDK in practice.
- This addition aims to provide users with practical insights and enhance the documentation's usability.