### PR TITLE
Add MCP tools for stub management and enhance API documentation

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -545,6 +545,7 @@ components:
         - serverVersion
         - transport
         - methods
+        - tools
       properties:
         protocolVersion:
           type: string
@@ -558,6 +559,33 @@ components:
           type: array
           items:
             type: string
+        tools:
+          type: array
+          items:
+            $ref: '#/components/schemas/McpTool'
+      example:
+        protocolVersion: "2024-11-05"
+        serverName: gripmock
+        serverVersion: 3.7.1
+        transport:
+          path: /api/mcp
+          methods: [GET, POST]
+        methods: [initialize, ping, tools/list, tools/call]
+        tools:
+          - name: stubs.upsert
+            description: Create or update one or many stubs
+            inputSchema:
+              type: object
+              required: [stubs]
+              properties:
+                stubs:
+                  oneOf:
+                    - type: object
+                    - type: array
+          - name: schema.stub
+            description: Return JSON Schema URL for stubs payload
+            inputSchema:
+              type: object
     McpRequest:
       type: object
       required:
@@ -576,6 +604,24 @@ components:
           additionalProperties: true
           x-go-type: map[string]any
           x-go-type-skip-optional-pointer: true
+      example:
+        jsonrpc: "2.0"
+        id: 10
+        method: tools/call
+        params:
+          name: stubs.upsert
+          arguments:
+            stubs:
+              service: unitconverter.v1.UnitConversionService
+              method: ConvertWeight
+              input:
+                equals:
+                  value: 1
+                  from_unit: POUNDS
+                  to_unit: KILOGRAMS
+              output:
+                data:
+                  converted_value: 0.453592
     McpError:
       type: object
       required:
@@ -608,6 +654,17 @@ components:
           x-go-type-skip-optional-pointer: true
         error:
           $ref: '#/components/schemas/McpError'
+      example:
+        jsonrpc: "2.0"
+        id: 10
+        result:
+          content:
+            - type: text
+              text: OK
+          structuredContent:
+            ids:
+              - fc800277-9bbb-4e0b-988e-4cf01b525085
+          isError: false
     McpID:
       nullable: true
       oneOf:

--- a/docs/guide/api/mcp/index.md
+++ b/docs/guide/api/mcp/index.md
@@ -6,6 +6,246 @@ GripMock supports MCP over HTTP JSON-RPC at `POST /api/mcp`.
 
 MCP gives AI agents a single integration point to inspect services, manage dynamic descriptors, and run debug/history workflows.
 
+## Available tools
+
+Use `tools/list` to discover the exact runtime set.
+
+- `descriptors.add`, `descriptors.list`
+- `services.list`, `services.delete`
+- `stubs.upsert`, `stubs.list`, `stubs.get`, `stubs.delete`, `stubs.batchDelete`, `stubs.purge`, `stubs.search`, `stubs.used`, `stubs.unused`
+- `schema.stub`
+- `history.list`, `history.errors`
+- `debug.call`
+
+Minimal end-to-end MCP flow:
+
+1. `tools/call` -> `descriptors.add`
+2. `tools/call` -> `stubs.upsert`
+3. external `grpcurl` call to `localhost:4770`
+4. `tools/call` -> `history.list` or `stubs.used`
+
+## JSON-RPC examples
+
+Initialize session:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize"
+}
+```
+
+List available tools:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/list"
+}
+```
+
+`stubs.upsert`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 10,
+  "method": "tools/call",
+  "params": {
+    "name": "stubs.upsert",
+    "arguments": {
+      "stubs": {
+        "service": "unitconverter.v1.UnitConversionService",
+        "method": "ConvertWeight",
+        "input": {
+          "equals": {
+            "value": 1,
+            "from_unit": "POUNDS",
+            "to_unit": "KILOGRAMS"
+          }
+        },
+        "output": {
+          "data": {
+            "converted_value": 0.453592
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+`stubs.list`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 11,
+  "method": "tools/call",
+  "params": {
+    "name": "stubs.list",
+    "arguments": {
+      "service": "unitconverter.v1.UnitConversionService",
+      "method": "ConvertWeight",
+      "limit": 10
+    }
+  }
+}
+```
+
+`stubs.get`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 12,
+  "method": "tools/call",
+  "params": {
+    "name": "stubs.get",
+    "arguments": {
+      "id": "fc800277-9bbb-4e0b-988e-4cf01b525085"
+    }
+  }
+}
+```
+
+`stubs.delete`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 13,
+  "method": "tools/call",
+  "params": {
+    "name": "stubs.delete",
+    "arguments": {
+      "id": "fc800277-9bbb-4e0b-988e-4cf01b525085"
+    }
+  }
+}
+```
+
+`stubs.batchDelete`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 14,
+  "method": "tools/call",
+  "params": {
+    "name": "stubs.batchDelete",
+    "arguments": {
+      "ids": [
+        "fc800277-9bbb-4e0b-988e-4cf01b525085",
+        "a6d58d6c-43ce-4c6e-8b2a-9f9a9ed6c8e1"
+      ]
+    }
+  }
+}
+```
+
+`stubs.purge`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 15,
+  "method": "tools/call",
+  "params": {
+    "name": "stubs.purge",
+    "arguments": {}
+  }
+}
+```
+
+`stubs.search`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 16,
+  "method": "tools/call",
+  "params": {
+    "name": "stubs.search",
+    "arguments": {
+      "service": "unitconverter.v1.UnitConversionService",
+      "method": "ConvertWeight",
+      "payload": {
+        "value": 1,
+        "from_unit": "POUNDS",
+        "to_unit": "KILOGRAMS"
+      }
+    }
+  }
+}
+```
+
+`stubs.used`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 17,
+  "method": "tools/call",
+  "params": {
+    "name": "stubs.used",
+    "arguments": {
+      "service": "unitconverter.v1.UnitConversionService"
+    }
+  }
+}
+```
+
+`stubs.unused`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 18,
+  "method": "tools/call",
+  "params": {
+    "name": "stubs.unused",
+    "arguments": {
+      "service": "unitconverter.v1.UnitConversionService"
+    }
+  }
+}
+```
+
+`history.list` (post-call verification):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 19,
+  "method": "tools/call",
+  "params": {
+    "name": "history.list",
+    "arguments": {
+      "service": "unitconverter.v1.UnitConversionService",
+      "method": "ConvertWeight",
+      "limit": 5
+    }
+  }
+}
+```
+
+`schema.stub` (stub schema URL discovery):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 20,
+  "method": "tools/call",
+  "params": {
+    "name": "schema.stub",
+    "arguments": {}
+  }
+}
+```
+
 This page focuses on connecting GripMock MCP to OpenCode.
 
 ## Endpoints

--- a/internal/app/errors.go
+++ b/internal/app/errors.go
@@ -139,6 +139,31 @@ func mcpDescriptorRegistrationArgError(err error) error {
 	return mcpInvalidArgErrorWithCause(err.Error(), err)
 }
 
+func mcpUUIDArgError(key, value string, err error) error {
+	message := key + " must be a UUID"
+	if value != "" {
+		message += ": " + value
+	}
+
+	if err == nil {
+		return mcpInvalidArgError(message)
+	}
+
+	return mcpInvalidArgErrorWithCause(message+": "+err.Error(), err)
+}
+
+func mcpStringListArgError(key string) error {
+	return mcpInvalidArgError(key + " must be a non-empty array of strings")
+}
+
+func mcpStubPayloadArgError(err error) error {
+	if err == nil {
+		return mcpInvalidArgError("invalid stubs payload")
+	}
+
+	return mcpInvalidArgErrorWithCause("invalid stubs payload: "+err.Error(), err)
+}
+
 func invalidFileDescriptorSetError(err error) error {
 	message := ErrInvalidFileDescriptorSet.Error()
 	if err != nil {

--- a/internal/app/rest_server_mcp_stubs_internal_test.go
+++ b/internal/app/rest_server_mcp_stubs_internal_test.go
@@ -1,0 +1,168 @@
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+)
+
+func (s *RestServerTestSuite) TestMCPStubsLifecycle() {
+	// Arrange
+	upsert := s.mcpToolCall(s.server, 1, "stubs.upsert", map[string]any{
+		"stubs": map[string]any{
+			"service": "unitconverter.v1.UnitConversionService",
+			"method":  "ConvertWeight",
+			"input": map[string]any{
+				"equals": map[string]any{"value": float64(1), "from_unit": "POUNDS", "to_unit": "KILOGRAMS"},
+			},
+			"output": map[string]any{"data": map[string]any{"converted_value": 0.453592}},
+		},
+	})
+	upsertJSON := s.mcpStructuredContent(upsert)
+	idsRaw, ok := upsertJSON["ids"].([]any)
+	s.Require().True(ok)
+	s.Require().Len(idsRaw, 1)
+	id, ok := idsRaw[0].(string)
+	s.Require().True(ok)
+
+	// Act
+	listed := s.mcpToolCall(s.server, 2, "stubs.list", map[string]any{"service": "unitconverter.v1.UnitConversionService"})
+	listedJSON := s.mcpStructuredContent(listed)
+	stubs, ok := listedJSON["stubs"].([]any)
+	s.Require().True(ok)
+
+	got := s.mcpToolCall(s.server, 3, "stubs.get", map[string]any{"id": id})
+	gotJSON := s.mcpStructuredContent(got)
+
+	deleted := s.mcpToolCall(s.server, 4, "stubs.delete", map[string]any{"id": id})
+	deletedJSON := s.mcpStructuredContent(deleted)
+
+	gotAfterDelete := s.mcpToolCall(s.server, 5, "stubs.get", map[string]any{"id": id})
+	gotAfterDeleteJSON := s.mcpStructuredContent(gotAfterDelete)
+
+	// Assert
+	s.Require().Len(stubs, 1)
+	s.Require().Equal(true, gotJSON["found"])
+	s.Require().Equal(true, deletedJSON["deleted"])
+	s.Require().Equal(false, gotAfterDeleteJSON["found"])
+}
+
+func (s *RestServerTestSuite) TestMCPStubsBatchDeleteAndPurge() {
+	// Arrange
+	first := s.mcpToolCall(s.server, 1, "stubs.upsert", map[string]any{
+		"stubs": map[string]any{
+			"service": "svc",
+			"method":  "M1",
+			"input":   map[string]any{"equals": map[string]any{"x": "1"}},
+			"output":  map[string]any{"data": map[string]any{"ok": true}},
+		},
+	})
+	firstJSON := s.mcpStructuredContent(first)
+	firstIDs, ok := firstJSON["ids"].([]any)
+	s.Require().True(ok)
+	s.Require().Len(firstIDs, 1)
+
+	second := s.mcpToolCall(s.server, 2, "stubs.upsert", map[string]any{
+		"stubs": map[string]any{
+			"service": "svc",
+			"method":  "M2",
+			"input":   map[string]any{"equals": map[string]any{"x": "2"}},
+			"output":  map[string]any{"data": map[string]any{"ok": true}},
+		},
+	})
+	secondJSON := s.mcpStructuredContent(second)
+	secondIDs, ok := secondJSON["ids"].([]any)
+	s.Require().True(ok)
+	s.Require().Len(secondIDs, 1)
+
+	// Act
+	batch := s.mcpToolCall(s.server, 3, "stubs.batchDelete", map[string]any{
+		"ids": []any{firstIDs[0], "00000000-0000-0000-0000-000000000099"},
+	})
+	batchJSON := s.mcpStructuredContent(batch)
+
+	purge := s.mcpToolCall(s.server, 4, "stubs.purge", map[string]any{})
+	purgeJSON := s.mcpStructuredContent(purge)
+
+	listAfter := s.mcpToolCall(s.server, 5, "stubs.list", map[string]any{})
+	listAfterJSON := s.mcpStructuredContent(listAfter)
+	deletedIDs, ok := batchJSON["deletedIds"].([]any)
+	s.Require().True(ok)
+	notFoundIDs, ok := batchJSON["notFoundIds"].([]any)
+	s.Require().True(ok)
+
+	// Assert
+	s.Require().Len(deletedIDs, 1)
+	s.Require().Len(notFoundIDs, 1)
+	s.Require().Equal(firstIDs[0], deletedIDs[0])
+	s.Require().Equal("00000000-0000-0000-0000-000000000099", notFoundIDs[0])
+	s.Require().InDelta(float64(1), purgeJSON["deletedCount"], 0)
+
+	stubsAfter, ok := listAfterJSON["stubs"].([]any)
+	s.Require().True(ok)
+	s.Require().Empty(stubsAfter)
+}
+
+func (s *RestServerTestSuite) TestMCPStubsSearch() {
+	// Arrange
+	s.mcpToolCall(s.server, 1, "stubs.upsert", map[string]any{
+		"stubs": map[string]any{
+			"service": "svc",
+			"method":  "Say",
+			"input":   map[string]any{"equals": map[string]any{"name": "john"}},
+			"output":  map[string]any{"data": map[string]any{"message": "hello"}},
+		},
+	})
+
+	// Act
+	found := s.mcpToolCall(s.server, 2, "stubs.search", map[string]any{
+		"service": "svc",
+		"method":  "Say",
+		"payload": map[string]any{"name": "john"},
+	})
+	foundJSON := s.mcpStructuredContent(found)
+
+	notFound := s.mcpToolCall(s.server, 3, "stubs.search", map[string]any{
+		"service": "svc",
+		"method":  "Say",
+		"payload": map[string]any{"name": "alice"},
+	})
+	notFoundJSON := s.mcpStructuredContent(notFound)
+
+	// Assert
+	s.Require().Equal(true, foundJSON["matched"])
+	s.Require().NotEmpty(foundJSON["stubId"])
+	s.Require().Equal(false, notFoundJSON["matched"])
+}
+
+func (s *RestServerTestSuite) TestMCPInfoIncludesTools() {
+	// Arrange
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	s.server.McpInfo(w, req)
+
+	// Assert
+	s.Require().Equal(http.StatusOK, w.Code)
+
+	var body map[string]any
+
+	err := json.Unmarshal(w.Body.Bytes(), &body)
+	s.Require().NoError(err)
+
+	tools, ok := body["tools"].([]any)
+	s.Require().True(ok)
+	s.Require().NotEmpty(tools)
+}
+
+func (s *RestServerTestSuite) TestMCPSchemaStub() {
+	// Act
+	response := s.mcpToolCall(s.server, 20, "schema.stub", map[string]any{})
+	structured := s.mcpStructuredContent(response)
+
+	// Assert
+	schemaURL, ok := structured["schemaUrl"].(string)
+	s.Require().True(ok)
+	s.Require().Equal("https://bavix.github.io/gripmock/schema/stub.json", schemaURL)
+}

--- a/internal/app/usecase/mcp/session.go
+++ b/internal/app/usecase/mcp/session.go
@@ -30,6 +30,8 @@ func ToolUsesSession(toolName string) bool {
 	switch toolName {
 	case ToolHistoryList, ToolHistoryErrors, ToolDebugCall:
 		return true
+	case ToolStubsUpsert, ToolStubsList, ToolStubsPurge, ToolStubsSearch, ToolStubsUsed, ToolStubsUnused:
+		return true
 	default:
 		return false
 	}

--- a/internal/app/usecase/mcp/tools.go
+++ b/internal/app/usecase/mcp/tools.go
@@ -8,6 +8,17 @@ const (
 	ToolHistoryList     = "history.list"
 	ToolHistoryErrors   = "history.errors"
 	ToolDebugCall       = "debug.call"
+	ToolSchemaStub      = "schema.stub"
+
+	ToolStubsUpsert      = "stubs.upsert"
+	ToolStubsList        = "stubs.list"
+	ToolStubsGet         = "stubs.get"
+	ToolStubsDelete      = "stubs.delete"
+	ToolStubsBatchDelete = "stubs.batchDelete"
+	ToolStubsPurge       = "stubs.purge"
+	ToolStubsSearch      = "stubs.search"
+	ToolStubsUsed        = "stubs.used"
+	ToolStubsUnused      = "stubs.unused"
 )
 
 func ListTools() []map[string]any {
@@ -19,7 +30,24 @@ func ListTools() []map[string]any {
 		historyListTool(),
 		historyErrorsTool(),
 		debugCallTool(),
+		schemaStubTool(),
 	}
+}
+
+func ListRuntimeTools() []map[string]any {
+	tools := append([]map[string]any{}, ListTools()...)
+
+	return append(tools,
+		stubsUpsertTool(),
+		stubsListTool(),
+		stubsGetTool(),
+		stubsDeleteTool(),
+		stubsBatchDeleteTool(),
+		stubsPurgeTool(),
+		stubsSearchTool(),
+		stubsUsedTool(),
+		stubsUnusedTool(),
+	)
 }
 
 func descriptorsAddTool() map[string]any {
@@ -122,5 +150,156 @@ func debugCallTool() map[string]any {
 				"stubsLimit": map[string]any{"type": "integer", "minimum": 0},
 			},
 		},
+	}
+}
+
+func schemaStubTool() map[string]any {
+	return map[string]any{
+		"name":        ToolSchemaStub,
+		"description": "Return JSON Schema URL for stubs payload",
+		"inputSchema": map[string]any{"type": "object"},
+	}
+}
+
+func stubsUpsertTool() map[string]any {
+	return map[string]any{
+		"name":        ToolStubsUpsert,
+		"description": "Create or update one or many stubs",
+		"inputSchema": map[string]any{
+			"type": "object",
+			"required": []string{
+				"stubs",
+			},
+			"properties": map[string]any{
+				"session": map[string]any{"type": "string"},
+				"stubs": map[string]any{
+					"description": "Stub object or array of stub objects",
+					"oneOf": []map[string]any{
+						{"type": "object", "additionalProperties": true},
+						{"type": "array", "items": map[string]any{"type": "object", "additionalProperties": true}},
+					},
+				},
+			},
+		},
+	}
+}
+
+func stubsListTool() map[string]any {
+	return map[string]any{
+		"name":        ToolStubsList,
+		"description": "List stubs with optional filters",
+		"inputSchema": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"service": map[string]any{"type": "string"},
+				"method":  map[string]any{"type": "string"},
+				"session": map[string]any{"type": "string"},
+				"limit":   map[string]any{"type": "integer", "minimum": 0},
+				"offset":  map[string]any{"type": "integer", "minimum": 0},
+			},
+		},
+	}
+}
+
+func stubsGetTool() map[string]any {
+	return map[string]any{
+		"name":        ToolStubsGet,
+		"description": "Get a stub by ID",
+		"inputSchema": map[string]any{
+			"type": "object",
+			"required": []string{
+				"id",
+			},
+			"properties": map[string]any{
+				"id": map[string]any{"type": "string"},
+			},
+		},
+	}
+}
+
+func stubsDeleteTool() map[string]any {
+	return map[string]any{
+		"name":        ToolStubsDelete,
+		"description": "Delete a stub by ID",
+		"inputSchema": map[string]any{
+			"type": "object",
+			"required": []string{
+				"id",
+			},
+			"properties": map[string]any{
+				"id": map[string]any{"type": "string"},
+			},
+		},
+	}
+}
+
+func stubsBatchDeleteTool() map[string]any {
+	return map[string]any{
+		"name":        ToolStubsBatchDelete,
+		"description": "Delete stubs by IDs",
+		"inputSchema": map[string]any{
+			"type": "object",
+			"required": []string{
+				"ids",
+			},
+			"properties": map[string]any{
+				"ids": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+			},
+		},
+	}
+}
+
+func stubsPurgeTool() map[string]any {
+	return map[string]any{
+		"name":        ToolStubsPurge,
+		"description": "Delete all stubs or session-scoped stubs",
+		"inputSchema": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"session": map[string]any{"type": "string"},
+			},
+		},
+	}
+}
+
+func stubsSearchTool() map[string]any {
+	return map[string]any{
+		"name":        ToolStubsSearch,
+		"description": "Search a matching stub by request payload",
+		"inputSchema": map[string]any{
+			"type": "object",
+			"required": []string{
+				"service",
+				"method",
+				"payload",
+			},
+			"properties": map[string]any{
+				"service": map[string]any{"type": "string"},
+				"method":  map[string]any{"type": "string"},
+				"session": map[string]any{"type": "string"},
+				"headers": map[string]any{"type": "object", "additionalProperties": true},
+				"payload": map[string]any{"type": "object", "additionalProperties": true},
+				"input": map[string]any{
+					"type":  "array",
+					"items": map[string]any{"type": "object", "additionalProperties": true},
+				},
+			},
+		},
+	}
+}
+
+func stubsUsedTool() map[string]any {
+	return map[string]any{
+		"name":        ToolStubsUsed,
+		"description": "List used stubs with optional filters",
+		"inputSchema": stubsListTool()["inputSchema"],
+	}
+}
+
+func stubsUnusedTool() map[string]any {
+	return map[string]any{
+		"name":        ToolStubsUnused,
+		"description": "List unused stubs with optional filters",
+		"inputSchema": stubsListTool()["inputSchema"],
 	}
 }

--- a/internal/app/usecase/mcp/tools_test.go
+++ b/internal/app/usecase/mcp/tools_test.go
@@ -20,6 +20,7 @@ func TestListTools_ContainsAllExpectedTools(t *testing.T) {
 		mcpusecase.ToolHistoryList:     {},
 		mcpusecase.ToolHistoryErrors:   {},
 		mcpusecase.ToolDebugCall:       {},
+		mcpusecase.ToolSchemaStub:      {},
 	}
 
 	// Act

--- a/internal/domain/rest/api.gen.go
+++ b/internal/domain/rest/api.gen.go
@@ -75,6 +75,7 @@ type McpInfoResponse struct {
 	ProtocolVersion string       `json:"protocolVersion"`
 	ServerName      string       `json:"serverName"`
 	ServerVersion   string       `json:"serverVersion"`
+	Tools           []McpTool    `json:"tools"`
 	Transport       McpTransport `json:"transport"`
 }
 
@@ -92,6 +93,13 @@ type McpResponse struct {
 	Id      *McpID         `json:"id"`
 	Jsonrpc string         `json:"jsonrpc"`
 	Result  map[string]any `json:"result,omitempty"`
+}
+
+// McpTool defines model for McpTool.
+type McpTool struct {
+	Description string         `json:"description"`
+	InputSchema map[string]any `json:"inputSchema"`
+	Name        string         `json:"name"`
 }
 
 // McpTransport defines model for McpTransport.


### PR DESCRIPTION
- Introduced new tools for managing stubs: `stubs.upsert`, `stubs.list`, `stubs.get`, `stubs.delete`, `stubs.batchDelete`, `stubs.purge`, `stubs.search`, `stubs.used`, and `stubs.unused`.
- Updated API schema to include a new `tools` array in the MCP info response.
- Enhanced documentation to provide examples for new tools and their usage.
- Added error handling functions for stub-related operations.
- Refactored existing code to integrate new tools into the MCP workflow.