### PR TITLE
feat(proxy): support local descriptor sources for proxy/capture/replay

### DIFF
--- a/docs/guide/modes/capture.md
+++ b/docs/guide/modes/capture.md
@@ -31,15 +31,17 @@ Capture stores request and upstream result in stub form:
 - `grpc+capture://host:port`
 - `grpcs+capture://host:port`
 
+If the upstream does not expose gRPC reflection, pair this URL with a local descriptor source — see [Upstreams without gRPC reflection](/guide/modes/#upstreams-without-grpc-reflection-v3-13-0).
+
 ## Query parameters
 
-| Parameter | Default | Description |
-|---|---|---|
-| `timeout` | `5s` | Timeout for upstream requests. |
-| `bearer` | — | Bearer token to include in upstream requests. |
-| `serverName` | — | Override TLS server name (SNI). |
-| `insecureSkipVerify` | `false` | Skip upstream TLS certificate verification. |
-| `recordDelay` | `false` | Record response latency as `delay` in captured stubs. |
+| Parameter            | Default | Description                                           |
+| -------------------- | ------- | ----------------------------------------------------- |
+| `timeout`            | `5s`    | Timeout for upstream requests.                        |
+| `bearer`             | —       | Bearer token to include in upstream requests.         |
+| `serverName`         | —       | Override TLS server name (SNI).                       |
+| `insecureSkipVerify` | `false` | Skip upstream TLS certificate verification.           |
+| `recordDelay`        | `false` | Record response latency as `delay` in captured stubs. |
 
 Example with delay recording enabled:
 

--- a/docs/guide/modes/index.md
+++ b/docs/guide/modes/index.md
@@ -23,6 +23,16 @@ For a typical Order Service rollout, modes let you move in predictable stages:
 - Reflection source (`grpc://`, `grpcs://`) => how descriptors are loaded.
 - Upstream mode (`+proxy`, `+replay`, `+capture`) => how runtime requests are resolved.
 
+## Upstreams without gRPC reflection <VersionTag version="v3.13.0" />
+
+If the upstream does **not** expose `grpc.reflection.v1.ServerReflection`, pass the schema yourself via any local descriptor source (`.proto`, `.protoset`, `.pb`, directory, or BSR module). When GripMock sees a local source alongside an upstream URL, it uses the local descriptors and never asks the upstream for its schema.
+
+```bash
+gripmock -i ./proto ./proto/orders.proto grpc+capture://orders.api.internal:8443
+```
+
+The URL still declares the upstream (`host:port`, mode, TLS, auth, timeout). Service-to-upstream binding is derived from the local descriptor pool. No additional flag or query parameter is required.
+
 ## URL schemes
 
 - `grpc+proxy://host:port`

--- a/docs/guide/modes/proxy.md
+++ b/docs/guide/modes/proxy.md
@@ -17,14 +17,16 @@ For unary and all streaming methods:
 - `grpc+proxy://host:port`
 - `grpcs+proxy://host:port`
 
+If the upstream does not expose gRPC reflection, pair this URL with a local descriptor source — see [Upstreams without gRPC reflection](/guide/modes/#upstreams-without-grpc-reflection-v3-13-0).
+
 ## Query parameters
 
-| Parameter | Default | Description |
-|---|---|---|
-| `timeout` | `5s` | Timeout for upstream requests. |
-| `bearer` | — | Bearer token to include in upstream requests. |
-| `serverName` | — | Override TLS server name (SNI). |
-| `insecureSkipVerify` | `false` | Skip upstream TLS certificate verification. |
+| Parameter            | Default | Description                                   |
+| -------------------- | ------- | --------------------------------------------- |
+| `timeout`            | `5s`    | Timeout for upstream requests.                |
+| `bearer`             | —       | Bearer token to include in upstream requests. |
+| `serverName`         | —       | Override TLS server name (SNI).               |
+| `insecureSkipVerify` | `false` | Skip upstream TLS certificate verification.   |
 
 Example:
 

--- a/docs/guide/modes/replay.md
+++ b/docs/guide/modes/replay.md
@@ -31,15 +31,17 @@ No heuristic shortcut is used for fallback decisions.
 - `grpc+replay://host:port`
 - `grpcs+replay://host:port`
 
+If the upstream does not expose gRPC reflection, pair this URL with a local descriptor source — see [Upstreams without gRPC reflection](/guide/modes/#upstreams-without-grpc-reflection-v3-13-0).
+
 ## Query parameters
 
-| Parameter | Default | Description |
-|---|---|---|
-| `timeout` | `5s` | Timeout for upstream requests. |
-| `bearer` | — | Bearer token to include in upstream requests. |
-| `serverName` | — | Override TLS server name (SNI). |
-| `insecureSkipVerify` | `false` | Skip upstream TLS certificate verification. |
-| `recordDelay` | `false` | Record response latency as `delay` in captured stubs (for upstream misses). |
+| Parameter            | Default | Description                                                                 |
+| -------------------- | ------- | --------------------------------------------------------------------------- |
+| `timeout`            | `5s`    | Timeout for upstream requests.                                              |
+| `bearer`             | —       | Bearer token to include in upstream requests.                               |
+| `serverName`         | —       | Override TLS server name (SNI).                                             |
+| `insecureSkipVerify` | `false` | Skip upstream TLS certificate verification.                                 |
+| `recordDelay`        | `false` | Record response latency as `delay` in captured stubs (for upstream misses). |
 
 ## Example
 

--- a/internal/app/grpc_server.go
+++ b/internal/app/grpc_server.go
@@ -1694,7 +1694,12 @@ func (s *GRPCServer) Build(ctx context.Context) (*grpc.Server, error) {
 		protoPaths = s.params.ProtoPath()
 	}
 
-	s.proxies, err = proxyroutes.New(ctx, protoPaths, s.remoteClient)
+	descriptors, err := protosetdom.Build(ctx, imports, protoPaths, s.remoteClient)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build descriptors")
+	}
+
+	s.proxies, err = proxyroutes.New(ctx, protoPaths, s.remoteClient, descriptors)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize proxy routes")
 	}
@@ -1704,11 +1709,6 @@ func (s *GRPCServer) Build(ctx context.Context) (*grpc.Server, error) {
 			<-ctx.Done()
 			s.proxies.Close()
 		}()
-	}
-
-	descriptors, err := protosetdom.Build(ctx, imports, protoPaths, s.remoteClient)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to build descriptors")
 	}
 
 	// Wait for stubs to load before registering services

--- a/internal/domain/protoset/handler_proxy.go
+++ b/internal/domain/protoset/handler_proxy.go
@@ -76,7 +76,7 @@ func (h *ProxyHandler) Parse(raw string) (*Source, error) {
 	}
 
 	return &Source{
-		Type:              SourceReflect,
+		Type:              SourceProxy,
 		Raw:               raw,
 		ReflectAddress:    parsed.Host,
 		ReflectTLS:        tlsEnabled,
@@ -89,16 +89,8 @@ func (h *ProxyHandler) Parse(raw string) (*Source, error) {
 	}, nil
 }
 
-func (h *ProxyHandler) Process(ctx context.Context, source *Source, processor SourceProcessor) error {
-	reflectProcessor, ok := processor.(interface {
-		ProcessReflect(ctx context.Context, source *Source) error
-	})
-
-	if !ok {
-		return nil
-	}
-
-	return reflectProcessor.ProcessReflect(ctx, source)
+func (h *ProxyHandler) Process(_ context.Context, _ *Source, _ SourceProcessor) error {
+	return nil
 }
 
 func parseProxyScheme(scheme string) (string, bool, error) {

--- a/internal/domain/protoset/handler_proxy_internal_test.go
+++ b/internal/domain/protoset/handler_proxy_internal_test.go
@@ -29,7 +29,7 @@ func TestProxyHandlerParse(t *testing.T) {
 
 	src, err := h.Parse("grpcs+capture://api.company.local:443?serverName=api.company.local&bearer=token&timeout=7s&insecureSkipVerify=true")
 	require.NoError(t, err)
-	require.Equal(t, SourceReflect, src.Type)
+	require.Equal(t, SourceProxy, src.Type)
 	require.Equal(t, "capture", src.ProxyMode)
 	require.Equal(t, "api.company.local:443", src.ReflectAddress)
 	require.True(t, src.ReflectTLS)

--- a/internal/domain/protoset/handlers_internal_test.go
+++ b/internal/domain/protoset/handlers_internal_test.go
@@ -76,6 +76,9 @@ func TestParseSource(t *testing.T) {
 				require.Equal(t, tt.wantVer, src.Version)
 			case SourceReflect:
 				require.NotEmpty(t, src.ReflectAddress)
+			case SourceProxy:
+				require.NotEmpty(t, src.ReflectAddress)
+				require.NotEmpty(t, src.ProxyMode)
 			case SourceProto, SourceDescriptor:
 				require.Equal(t, tt.wantPath, src.Path)
 			case SourceDirectory, SourceUnknown:
@@ -107,6 +110,8 @@ func makeParseSourceCases() []parseSourceCase {
 	cases = append(cases,
 		parseSourceCase{name: "grpc reflection source", raw: "grpc://localhost:50051", wantType: SourceReflect},
 		parseSourceCase{name: "grpcs reflection source", raw: "grpcs://api.company.local:443", wantType: SourceReflect},
+		parseSourceCase{name: "grpc+capture proxy source", raw: "grpc+capture://localhost:50051", wantType: SourceProxy},
+		parseSourceCase{name: "grpcs+replay proxy source", raw: "grpcs+replay://api.company.local:443", wantType: SourceProxy},
 		fileCase(".proto file", "service.proto", SourceProto),
 		fileCase(".pb file", "service.pb", SourceDescriptor),
 		fileCase(".protoset file", "service.protoset", SourceDescriptor),

--- a/internal/domain/protoset/source_handler.go
+++ b/internal/domain/protoset/source_handler.go
@@ -39,6 +39,8 @@ func ProcessSource(ctx context.Context, source *Source, processor SourceProcesso
 	switch source.Type {
 	case SourceUnknown:
 		return nil
+	case SourceProxy:
+		return nil
 	case SourceBufBuild:
 		handler = &BufBuildHandler{}
 	case SourceReflect:

--- a/internal/domain/protoset/transform.go
+++ b/internal/domain/protoset/transform.go
@@ -323,7 +323,7 @@ func Build(
 			return nil, errors.Wrapf(err, "failed to parse source: %s", path)
 		}
 
-		if source.Type == SourceBufBuild || source.Type == SourceReflect {
+		if source.Type == SourceBufBuild || source.Type == SourceReflect || source.Type == SourceProxy {
 			continue
 		}
 

--- a/internal/domain/protoset/transform_internal_test.go
+++ b/internal/domain/protoset/transform_internal_test.go
@@ -539,3 +539,22 @@ func TestConstants(t *testing.T) {
 	require.Equal(t, ".pb", ProtobufSetExt)
 	require.Equal(t, ".protoset", ProtoSetExt)
 }
+
+func TestBuildDoesNotFetchDescriptorsForProxySources(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	client := &mockRemoteClient{fn: func(_ *Source) *descriptorpb.FileDescriptorSet {
+		calls++
+
+		return &descriptorpb.FileDescriptorSet{}
+	}}
+
+	_, err := Build(t.Context(), nil, []string{
+		"grpc+capture://upstream.example:443",
+		"grpcs+replay://other.example:8443",
+		"grpc+proxy://third.example:50051",
+	}, client)
+	require.NoError(t, err)
+	require.Equal(t, 0, calls)
+}

--- a/internal/domain/protoset/types.go
+++ b/internal/domain/protoset/types.go
@@ -11,6 +11,7 @@ const (
 	SourceProto
 	SourceDescriptor
 	SourceDirectory
+	SourceProxy
 )
 
 type Source struct {

--- a/internal/infra/proxyroutes/routes.go
+++ b/internal/infra/proxyroutes/routes.go
@@ -37,8 +37,41 @@ type Registry struct {
 	index  map[string]*Route
 }
 
-//nolint:cyclop,funlen
-func New(ctx context.Context, paths []string, remoteClient protosetdom.RemoteClient) (*Registry, error) {
+func New(
+	ctx context.Context,
+	paths []string,
+	remoteClient protosetdom.RemoteClient,
+	localDescriptors []*descriptorpb.FileDescriptorSet,
+) (*Registry, error) {
+	sources, err := parseProxySources(paths)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(sources) == 0 {
+		return &Registry{}, nil
+	}
+
+	localServices := collectServiceMethodsAll(localDescriptors)
+
+	routes := make([]*Route, 0, len(sources))
+	index := make(map[string]*Route)
+	assignedServices := make(map[string]struct{})
+
+	for _, source := range sources {
+		route, serviceMethods, err := buildRoute(ctx, source, remoteClient, localServices)
+		if err != nil {
+			return nil, err
+		}
+
+		bindServices(route, serviceMethods, index, assignedServices)
+		routes = append(routes, route)
+	}
+
+	return &Registry{routes: routes, index: index}, nil
+}
+
+func parseProxySources(paths []string) ([]*protosetdom.Source, error) {
 	sources := make([]*protosetdom.Source, 0, len(paths))
 
 	for _, path := range paths {
@@ -54,59 +87,79 @@ func New(ctx context.Context, paths []string, remoteClient protosetdom.RemoteCli
 		sources = append(sources, source)
 	}
 
-	if len(sources) == 0 {
-		return &Registry{}, nil
+	return sources, nil
+}
+
+func buildRoute(
+	ctx context.Context,
+	source *protosetdom.Source,
+	remoteClient protosetdom.RemoteClient,
+	localServices map[string][]string,
+) (*Route, map[string][]string, error) {
+	serviceMethods, err := resolveServiceMethods(ctx, source, remoteClient, localServices)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	conn, err := grpc.NewClient("passthrough:///"+source.ReflectAddress, grpcclient.DialOptions(
+		source.ReflectTimeout,
+		source.ReflectTLS,
+		source.ReflectServerName,
+		source.ReflectBearer,
+		source.ReflectInsecure,
+	)...)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "failed to connect proxy upstream: %s", source.ReflectAddress)
+	}
+
+	return &Route{
+		Mode:   mapMode(source.ProxyMode),
+		Source: source,
+		Conn:   conn,
+	}, serviceMethods, nil
+}
+
+func bindServices(
+	route *Route,
+	serviceMethods map[string][]string,
+	index map[string]*Route,
+	assignedServices map[string]struct{},
+) {
+	for service, methods := range serviceMethods {
+		if _, exists := assignedServices[service]; exists {
+			continue
+		}
+
+		assignedServices[service] = struct{}{}
+
+		for _, method := range methods {
+			if _, exists := index[method]; !exists {
+				index[method] = route
+			}
+		}
+	}
+}
+
+func resolveServiceMethods(
+	ctx context.Context,
+	source *protosetdom.Source,
+	remoteClient protosetdom.RemoteClient,
+	localServices map[string][]string,
+) (map[string][]string, error) {
+	if len(localServices) > 0 {
+		return localServices, nil
 	}
 
 	if remoteClient == nil {
 		return nil, errRemoteClientNil
 	}
 
-	routes := make([]*Route, 0, len(sources))
-	index := make(map[string]*Route)
-	assignedServices := make(map[string]struct{})
-
-	for _, source := range sources {
-		fds, err := remoteClient.FetchDescriptorSet(ctx, source)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to fetch proxy descriptors: %s", source.Raw)
-		}
-
-		conn, err := grpc.NewClient("passthrough:///"+source.ReflectAddress, grpcclient.DialOptions(
-			source.ReflectTimeout,
-			source.ReflectTLS,
-			source.ReflectServerName,
-			source.ReflectBearer,
-			source.ReflectInsecure,
-		)...)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to connect proxy upstream: %s", source.ReflectAddress)
-		}
-
-		route := &Route{
-			Mode:   mapMode(source.ProxyMode),
-			Source: source,
-			Conn:   conn,
-		}
-
-		for service, methods := range collectServiceMethods(fds) {
-			if _, exists := assignedServices[service]; exists {
-				continue
-			}
-
-			assignedServices[service] = struct{}{}
-
-			for _, method := range methods {
-				if _, exists := index[method]; !exists {
-					index[method] = route
-				}
-			}
-		}
-
-		routes = append(routes, route)
+	fds, err := remoteClient.FetchDescriptorSet(ctx, source)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to fetch proxy descriptors: %s", source.Raw)
 	}
 
-	return &Registry{routes: routes, index: index}, nil
+	return collectServiceMethods(fds), nil
 }
 
 func (r *Registry) RouteByMethod(fullMethod string) *Route {
@@ -175,6 +228,22 @@ func mapMode(mode string) Mode {
 	default:
 		return ModeProxy
 	}
+}
+
+func collectServiceMethodsAll(fdsList []*descriptorpb.FileDescriptorSet) map[string][]string {
+	if len(fdsList) == 0 {
+		return nil
+	}
+
+	merged := make(map[string][]string)
+
+	for _, fds := range fdsList {
+		for service, methods := range collectServiceMethods(fds) {
+			merged[service] = append(merged[service], methods...)
+		}
+	}
+
+	return merged
 }
 
 func collectServiceMethods(fds *descriptorpb.FileDescriptorSet) map[string][]string {

--- a/internal/infra/proxyroutes/routes_internal_test.go
+++ b/internal/infra/proxyroutes/routes_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/descriptorpb"
 
@@ -11,10 +12,18 @@ import (
 )
 
 type fakeRemoteClient struct {
-	sets map[string]*descriptorpb.FileDescriptorSet
+	sets    map[string]*descriptorpb.FileDescriptorSet
+	calls   int
+	failAll bool
 }
 
-func (f fakeRemoteClient) FetchDescriptorSet(_ context.Context, source *protosetdom.Source) (*descriptorpb.FileDescriptorSet, error) {
+func (f *fakeRemoteClient) FetchDescriptorSet(_ context.Context, source *protosetdom.Source) (*descriptorpb.FileDescriptorSet, error) {
+	f.calls++
+
+	if f.failAll {
+		return nil, errors.New("reflection unavailable")
+	}
+
 	return f.sets[source.ReflectAddress], nil
 }
 
@@ -36,7 +45,7 @@ func TestRegistryRouteByMethodNoFallback(t *testing.T) {
 func TestNewFirstSourceWinsPerService(t *testing.T) {
 	t.Parallel()
 
-	client := fakeRemoteClient{sets: map[string]*descriptorpb.FileDescriptorSet{
+	client := &fakeRemoteClient{sets: map[string]*descriptorpb.FileDescriptorSet{
 		"proxy:123": buildDescriptorSet(map[string][]string{
 			"greeter":  {"Ping"},
 			"greeter1": {"Ping"},
@@ -55,7 +64,7 @@ func TestNewFirstSourceWinsPerService(t *testing.T) {
 		"grpc+proxy://proxy:123",
 		"grpc+replay://proxy1:321",
 		"grpc+capture://proxy2:444",
-	}, client)
+	}, client, nil)
 	require.NoError(t, err)
 	t.Cleanup(r.Close)
 
@@ -64,6 +73,53 @@ func TestNewFirstSourceWinsPerService(t *testing.T) {
 	require.Equal(t, ModeReplay, r.RouteByMethod("/greeter2/Ping").Mode)
 	require.Equal(t, ModeCapture, r.RouteByMethod("/greeter3/Ping").Mode)
 	require.Nil(t, r.RouteByMethod("/unknown/Method"))
+}
+
+func TestNewSkipsReflectionWhenLocalDescriptorsPresent(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeRemoteClient{failAll: true}
+
+	local := []*descriptorpb.FileDescriptorSet{
+		buildDescriptorSet(map[string][]string{
+			"orders.OrderService": {"Create", "Get"},
+		}),
+	}
+
+	r, err := New(
+		context.Background(),
+		[]string{"grpc+capture://orders.internal:443"},
+		client,
+		local,
+	)
+	require.NoError(t, err)
+	t.Cleanup(r.Close)
+
+	require.Equal(t, 0, client.calls)
+	require.Equal(t, ModeCapture, r.RouteByMethod("/orders.OrderService/Create").Mode)
+	require.Equal(t, ModeCapture, r.RouteByMethod("/orders.OrderService/Get").Mode)
+}
+
+func TestNewUsesReflectionWhenLocalDescriptorsAbsent(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeRemoteClient{sets: map[string]*descriptorpb.FileDescriptorSet{
+		"orders.internal:443": buildDescriptorSet(map[string][]string{
+			"orders.OrderService": {"Create"},
+		}),
+	}}
+
+	r, err := New(
+		context.Background(),
+		[]string{"grpc+capture://orders.internal:443"},
+		client,
+		nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(r.Close)
+
+	require.Equal(t, 1, client.calls)
+	require.Equal(t, ModeCapture, r.RouteByMethod("/orders.OrderService/Create").Mode)
 }
 
 func buildDescriptorSet(services map[string][]string) *descriptorpb.FileDescriptorSet {

--- a/internal/infra/sourceclient/router.go
+++ b/internal/infra/sourceclient/router.go
@@ -37,7 +37,7 @@ func (r *Router) FetchDescriptorSet(ctx context.Context, source *protoset.Source
 		}
 
 		return r.bsrClient.FetchDescriptorSet(ctx, source.Module, source.Version)
-	case protoset.SourceReflect:
+	case protoset.SourceReflect, protoset.SourceProxy:
 		if r.reflectClient == nil {
 			return nil, errReflectClientNotConfigured
 		}


### PR DESCRIPTION
## Motivation

Today `grpc+{proxy,capture,replay}://` requires the upstream to expose `grpc.reflection.v1.ServerReflection`. Many production gRPC servers do not (security policy, intentional stripping, or simply not implemented). Users who already have the `.proto` files locally cannot use these modes at all.

This PR lets users pair a local descriptor source with a proxy URL:

```bash
gripmock -i ./proto ./proto/orders.proto grpc+capture://orders.api:443
```

When local descriptors are present, gripmock uses them to bind services and skips the reflection fetch entirely. When no local source is given, behaviour is unchanged.

## Design

`SourceProxy` is introduced as a first-class source type, distinct from `SourceReflect`. Proxy URLs are routing destinations, not descriptor sources, and no longer flow through the eager reflection fetch in `protosetdom.Build`. The routing layer (`proxyroutes.New`) consumes the already-built descriptor pool; if it is empty, it falls back to the legacy upstream reflection fetch lazily, at route-build time.

Backward compatible: every existing invocation behaves identically.

## Disclosure

Most of this PR was written by Claude Code (Anthropic). I reviewed each diff, ran tests + lint locally, and verified the end-to-end behaviour by running the built image against a real reflection-less upstream and confirming capture + replay worked. My personal goal (recording traffic against a specific reflection-less server) is achieved.

That said: LLMs hallucinate, and I have not yet contributed to this codebase, so I cannot judge whether the design choices fit the project's conventions as well as a maintainer can. I would appreciate a careful review — especially of:

- the introduction of \`SourceProxy\` as a separate type vs. extending \`SourceReflect\`,
- the ordering swap in \`grpc_server.go\` (\`protosetdom.Build\` now runs before \`proxyroutes.New\`),
- whether the local-descriptors short-circuit in \`proxyroutes.New\` is the right shape, or whether you'd prefer a different surface.

Happy to iterate on naming, structure, or scope.

## Tests

- \`proxyroutes\` — two new cases: reflection is not called when local descriptors are present; legacy path still works when they are not.
- \`protoset\` — regression test: \`Build\` makes zero descriptor-fetch calls for proxy URLs.
- \`protoset\` — \`ParseSource\` dispatcher covers \`grpc+capture://\` and \`grpcs+replay://\` resolving to \`SourceProxy\`.

\`make test\` and \`make lint\` clean locally.

## Docs

- \`docs/guide/modes/index.md\` — new section "Upstreams without gRPC reflection" with a runnable example.
- \`docs/guide/modes/{proxy,capture,replay}.md\` — short pointer back to the canonical section.